### PR TITLE
Attempt rescale of u8 input values

### DIFF
--- a/test/src/Main.idr
+++ b/test/src/Main.idr
@@ -43,7 +43,7 @@ downSample chunkLen xs with (splitAt (cast chunkLen) xs)
   _ | (chunk, rest) = recoverWave (average chunk) :: downSample chunkLen rest
 
 thresholdFilter : Int -> List Int16 -> List Int16
-thresholdFilter t xs = map (\v => if v > (cast t) then v else 0) xs
+thresholdFilter t xs = map (\v => if abs(v) > (cast t) then v else 0) xs
 
 writeBufToFile : String -> List Int16 -> IO ()
 writeBufToFile fpath bytes = do


### PR DESCRIPTION
This attempts to rescale the input i and q waves to remove DC offset and preserves precision of amplitudes between 0 - 1. Then rescales the output int16 stream to take values between 0 - 32767. Finally, increase the sampling rate to (20 * 48)kHz so when downsampling of 20 occurs, the result is a 48kHz rate audio stream.